### PR TITLE
Opam: forcing dependencies for a correct installation procedure.

### DIFF
--- a/cameleer.opam
+++ b/cameleer.opam
@@ -24,7 +24,10 @@ depends: [
   "fmt"
   "ocaml" {>= "4.07"}
   "ppxlib" {>= "0.23.0"}
-  (("lablgtk" & "conf-gtksourceview") | ("lablgtk3" & "lablgtk3-sourceview3"))
+  "sexplib"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  ("lablgtk3" & "lablgtk3-sourceview3")
 ]
 
 conflicts: [


### PR DESCRIPTION
This fixes the problems of loading `sexplib` in the Cameleer plugin.