### PR TITLE
include sexplib0 in why3 plugin

### DIFF
--- a/plugin/dune
+++ b/plugin/dune
@@ -2,7 +2,7 @@
  (libraries ppxlib gospel why3 cameleer)
  (name plugin_cameleer)
  (modes plugin)
- (embed_in_plugin_libraries compiler-libs.common ocaml-compiler-libs.shadow
+ (embed_in_plugin_libraries sexplib0 compiler-libs.common ocaml-compiler-libs.shadow
    ppxlib.astlib ppxlib.stdppx ppxlib.ast ppxlib fmt gospel cameleer))
 
 (install


### PR DESCRIPTION
It looks like embedding sexplib0 in cameleer's why3 plugin solves #17 . I don't know whether there are cases where `sexplib0` might already be included by why3 itself, though.